### PR TITLE
Add JWP specific Size struct

### DIFF
--- a/lib/web_driver_client.ex
+++ b/lib/web_driver_client.ex
@@ -182,14 +182,8 @@ defmodule WebDriverClient do
           w3c: &W3CCommands.FetchWindowRect.parse_response/1
         ],
         fn
-          {:ok, %Size{} = size} ->
-            {:ok, size}
-
-          {:ok, %W3CWireProtocolClient.Rect{width: width, height: height}} ->
-            {:ok, %Size{width: width, height: height}}
-
-          {:error, error} ->
-            {:error, to_error(error)}
+          {:ok, size} -> {:ok, to_size(size)}
+          {:error, error} -> {:error, to_error(error)}
         end
       )
     end
@@ -851,6 +845,13 @@ defmodule WebDriverClient do
     |> Map.from_struct()
     |> (&struct!(ServerStatus, &1)).()
   end
+
+  @spec to_size(W3CWireProtocolClient.Rect.t() | JSONWireProtocolClient.Size.t()) :: Size.t()
+  defp to_size(%JSONWireProtocolClient.Size{width: width, height: height}),
+    do: %Size{width: width, height: height}
+
+  defp to_size(%W3CWireProtocolClient.Rect{width: width, height: height}),
+    do: %Size{width: width, height: height}
 
   defp to_error(%JSONWireProtocolClient.WebDriverError{reason: reason}) do
     reason =

--- a/lib/web_driver_client/json_wire_protocol_client.ex
+++ b/lib/web_driver_client/json_wire_protocol_client.ex
@@ -21,11 +21,11 @@ defmodule WebDriverClient.JSONWireProtocolClient do
   alias WebDriverClient.JSONWireProtocolClient.Cookie
   alias WebDriverClient.JSONWireProtocolClient.LogEntry
   alias WebDriverClient.JSONWireProtocolClient.ServerStatus
+  alias WebDriverClient.JSONWireProtocolClient.Size
   alias WebDriverClient.JSONWireProtocolClient.UnexpectedResponseError
   alias WebDriverClient.JSONWireProtocolClient.WebDriverError
   alias WebDriverClient.KeyCodes
   alias WebDriverClient.Session
-  alias WebDriverClient.Size
 
   @type url :: String.t()
   @type attribute_name :: String.t()

--- a/lib/web_driver_client/json_wire_protocol_client/commands/fetch_window_size.ex
+++ b/lib/web_driver_client/json_wire_protocol_client/commands/fetch_window_size.ex
@@ -5,11 +5,11 @@ defmodule WebDriverClient.JSONWireProtocolClient.Commands.FetchWindowSize do
   alias WebDriverClient.ConnectionError
   alias WebDriverClient.HTTPResponse
   alias WebDriverClient.JSONWireProtocolClient.ResponseParser
+  alias WebDriverClient.JSONWireProtocolClient.Size
   alias WebDriverClient.JSONWireProtocolClient.TeslaClientBuilder
   alias WebDriverClient.JSONWireProtocolClient.UnexpectedResponseError
   alias WebDriverClient.JSONWireProtocolClient.WebDriverError
   alias WebDriverClient.Session
-  alias WebDriverClient.Size
 
   @spec send_request(Session.t()) :: {:ok, HTTPResponse.t()} | {:error, ConnectionError.t()}
   def send_request(%Session{id: id, config: %Config{} = config}) do

--- a/lib/web_driver_client/json_wire_protocol_client/response_parser.ex
+++ b/lib/web_driver_client/json_wire_protocol_client/response_parser.ex
@@ -11,10 +11,10 @@ defmodule WebDriverClient.JSONWireProtocolClient.ResponseParser do
   alias WebDriverClient.JSONWireProtocolClient.LogEntry
   alias WebDriverClient.JSONWireProtocolClient.Response
   alias WebDriverClient.JSONWireProtocolClient.Response.Status
+  alias WebDriverClient.JSONWireProtocolClient.Size
   alias WebDriverClient.JSONWireProtocolClient.UnexpectedResponseError
   alias WebDriverClient.JSONWireProtocolClient.WebDriverError
   alias WebDriverClient.Session
-  alias WebDriverClient.Size
 
   defguardp is_status(term) when is_integer(term) and term >= 0
 

--- a/lib/web_driver_client/json_wire_protocol_client/size.ex
+++ b/lib/web_driver_client/json_wire_protocol_client/size.ex
@@ -1,0 +1,15 @@
+# credo:disable-for-this-file Credo.Check.Readability.ModuleDoc
+import WebDriverClient.CompatibilityMacros
+
+defmodule WebDriverClient.JSONWireProtocolClient.Size do
+  prerelease_moduledoc """
+  A width and height combination
+  """
+
+  defstruct [:width, :height]
+
+  @type t :: %__MODULE__{
+          height: non_neg_integer,
+          width: non_neg_integer
+        }
+end

--- a/test/web_driver_client/json_wire_protocol_client/response_parser_test.exs
+++ b/test/web_driver_client/json_wire_protocol_client/response_parser_test.exs
@@ -8,11 +8,11 @@ defmodule WebDriverClient.JSONWireProtocolClient.ResponseParserTest do
   alias WebDriverClient.JSONWireProtocolClient.LogEntry
   alias WebDriverClient.JSONWireProtocolClient.Response
   alias WebDriverClient.JSONWireProtocolClient.ResponseParser
+  alias WebDriverClient.JSONWireProtocolClient.Size
   alias WebDriverClient.JSONWireProtocolClient.TestResponses
   alias WebDriverClient.JSONWireProtocolClient.UnexpectedResponseError
   alias WebDriverClient.JSONWireProtocolClient.WebDriverError
   alias WebDriverClient.Session
-  alias WebDriverClient.Size
   alias WebDriverClient.TestData
 
   property "parse_response/1 returns {:ok, %Response{}} on valid JWP response" do

--- a/test/web_driver_client/json_wire_protocol_client_test.exs
+++ b/test/web_driver_client/json_wire_protocol_client_test.exs
@@ -10,11 +10,11 @@ defmodule WebDriverClient.JSONWireProtocolClientTest do
   alias WebDriverClient.JSONWireProtocolClient.Cookie
   alias WebDriverClient.JSONWireProtocolClient.LogEntry
   alias WebDriverClient.JSONWireProtocolClient.ServerStatus
+  alias WebDriverClient.JSONWireProtocolClient.Size
   alias WebDriverClient.JSONWireProtocolClient.TestResponses
   alias WebDriverClient.JSONWireProtocolClient.UnexpectedResponseError
   alias WebDriverClient.KeyCodes
   alias WebDriverClient.Session
-  alias WebDriverClient.Size
   alias WebDriverClient.TestData
 
   @moduletag :bypass


### PR DESCRIPTION
This adds a JWP specific `Size` struct for the `WebDriverClient.JSONWireProtocolClient` API. There was already one for `WebDriverClient.W3CWireProtocolClient.Rect` so not having one for the JWP `Size` was inconsistent.

The idea behind this is `WebDriverClient.JSONWireProtocolClient` and `WebDriverClient.W3CWireProtocolClient` will be standalone low-level APIs that directly support all of the features of each protocol. In order to keep each low-level API isolated and return additional protocol-specific data, all structs returned by these API should be namespaced below the parent API ( like `WebDriverClient.JSONWireProtocolClient.Size`). Then if the user wants to call the higher-level, protocol-agnostic `WebDriverClient` API, they'll be returned more generic structs that work for both protocols like `WebDriverClient.Size`, `WebDriverClient.Cookie`, etc.

This PR also cleans up some of the weird domain-translation code in `WebDriverClient` before I extend the pattern to add `fetch_element_size/2` in an upcoming PR.