### PR TITLE
Require base_url param for Config.build/2

### DIFF
--- a/lib/web_driver_client/config.ex
+++ b/lib/web_driver_client/config.ex
@@ -13,7 +13,7 @@ defmodule WebDriverClient.Config do
           debug?: boolean
         }
 
-  @type build_opt :: {:base_url, String.t()} | {:protocol, protocol} | {:debug, boolean}
+  @type build_opt :: {:protocol, protocol} | {:debug, boolean}
 
   @default_protocol :w3c
   @protocols [:jwp, :w3c]
@@ -21,9 +21,8 @@ defmodule WebDriverClient.Config do
   @doc """
   Builds a new `#{__MODULE__}` struct.
   """
-  @spec build([build_opt]) :: t
-  def build(opts) when is_list(opts) do
-    base_url = Keyword.fetch!(opts, :base_url)
+  @spec build(String.t(), [build_opt]) :: t
+  def build(base_url, opts \\ []) when is_binary(base_url) and is_list(opts) do
     protocol = Keyword.get(opts, :protocol, @default_protocol)
     debug = Keyword.get(opts, :debug, false)
     %__MODULE__{base_url: base_url, protocol: protocol, debug?: debug}

--- a/test/support/api_client_case.ex
+++ b/test/support/api_client_case.ex
@@ -24,7 +24,9 @@ defmodule WebDriverClient.APIClientCase do
   end
 
   defp config_from_bypass(%Bypass{} = bypass, context) do
-    Config.build(base_url: bypass_url(bypass))
+    bypass
+    |> bypass_url()
+    |> Config.build()
     |> maybe_update_protocol(context)
   end
 

--- a/test/support/integration_testing/scenarios.ex
+++ b/test/support/integration_testing/scenarios.ex
@@ -70,7 +70,9 @@ defmodule WebDriverClient.IntegrationTesting.Scenarios do
 
   @spec get_config(Scenario.t()) :: Config.t()
   def get_config(%Scenario{driver: driver, protocol: protocol}) do
-    Config.build(base_url: get_base_url(driver), protocol: protocol, debug: true)
+    driver
+    |> get_base_url()
+    |> Config.build(protocol: protocol, debug: true)
   end
 
   @spec get_start_session_payload(Scenario.t()) :: map()

--- a/test/web_driver_client/config_test.exs
+++ b/test/web_driver_client/config_test.exs
@@ -5,36 +5,30 @@ defmodule WebDriverClient.ConfigTest do
 
   @default_protocol :w3c
 
-  @required_opts [base_url: "http://www.foo.com:8000"]
+  @base_url "http://example.com"
 
-  test "build/1 sets the opts on the struct" do
+  test "build/2 sets the opts on the struct" do
     base_url = "http://www.foo.com:8000"
     protocol = :jwp
     debug = true
 
     assert %Config{base_url: ^base_url, protocol: ^protocol, debug?: ^debug} =
-             Config.build(base_url: base_url, protocol: protocol, debug: debug)
-  end
-
-  test "build/1 raises a KeyError if base url is not given" do
-    assert_raise KeyError, fn ->
-      Config.build([])
-    end
+             Config.build(base_url, protocol: protocol, debug: debug)
   end
 
   test "build/1 defaults protocol to w3c" do
-    assert %Config{protocol: @default_protocol} = Config.build(@required_opts)
+    assert %Config{protocol: @default_protocol} = Config.build(@base_url)
   end
 
   test "build/1 defaults debug to false" do
-    assert %Config{debug?: false} = Config.build(@required_opts)
+    assert %Config{debug?: false} = Config.build(@base_url)
   end
 
   test "put_protocol/2 allows updating the protocol to w3c" do
     protocol = :w3c
 
     config =
-      @required_opts
+      @base_url
       |> Config.build()
       |> Config.put_protocol(protocol)
 
@@ -45,7 +39,7 @@ defmodule WebDriverClient.ConfigTest do
     protocol = :w3c
 
     config =
-      @required_opts
+      @base_url
       |> Config.build()
       |> Config.put_protocol(protocol)
 
@@ -54,7 +48,7 @@ defmodule WebDriverClient.ConfigTest do
 
   test "put_protocol/2 disallows updating protocol to unknown protocol" do
     protocol = :invalid
-    config = Config.build(@required_opts)
+    config = Config.build(@base_url)
 
     assert_raise FunctionClauseError, fn ->
       Config.put_protocol(config, protocol)


### PR DESCRIPTION
This requires the `base_url` on `Config.build/2` by making it a positional argument so there is no way to call this function without passing a base url. The rest of the options can be defaulted, but it seems to make sense to require the base URL since each kind of web driver (phantomjs, chrome, selenium, etc) run on different ports.