### PR TITLE
Add config key for http_client_options

### DIFF
--- a/lib/web_driver_client/config.ex
+++ b/lib/web_driver_client/config.ex
@@ -3,17 +3,18 @@ defmodule WebDriverClient.Config do
   Configuration for the webdriver connection
   """
 
-  defstruct [:base_url, :protocol, :debug?]
+  defstruct [:base_url, :protocol, :debug?, :http_client_options]
 
   @type protocol :: :jwp | :w3c
 
   @type t :: %__MODULE__{
           base_url: String.t(),
           protocol: protocol,
-          debug?: boolean
+          debug?: boolean,
+          http_client_options: list()
         }
 
-  @type build_opt :: {:protocol, protocol} | {:debug, boolean}
+  @type build_opt :: {:protocol, protocol} | {:debug, boolean} | {:http_client_options, list}
 
   @default_protocol :w3c
   @protocols [:jwp, :w3c]
@@ -25,7 +26,14 @@ defmodule WebDriverClient.Config do
   def build(base_url, opts \\ []) when is_binary(base_url) and is_list(opts) do
     protocol = Keyword.get(opts, :protocol, @default_protocol)
     debug = Keyword.get(opts, :debug, false)
-    %__MODULE__{base_url: base_url, protocol: protocol, debug?: debug}
+    http_client_options = Keyword.get(opts, :http_client_options, [])
+
+    %__MODULE__{
+      base_url: base_url,
+      protocol: protocol,
+      debug?: debug,
+      http_client_options: http_client_options
+    }
   end
 
   @doc """

--- a/lib/web_driver_client/json_wire_protocol_client/tesla_client_builder.ex
+++ b/lib/web_driver_client/json_wire_protocol_client/tesla_client_builder.ex
@@ -4,8 +4,12 @@ defmodule WebDriverClient.JSONWireProtocolClient.TeslaClientBuilder do
   alias WebDriverClient.Config
 
   @spec build_simple(Config.t()) :: Client.t()
-  def build_simple(%Config{base_url: base_url, debug?: debug?}) do
-    adapter = {Tesla.Adapter.Hackney, [recv_timeout: 30_000]}
+  def build_simple(%Config{
+        base_url: base_url,
+        debug?: debug?,
+        http_client_options: http_client_options
+      }) do
+    adapter = {Tesla.Adapter.Hackney, http_client_options}
 
     middleware =
       [

--- a/lib/web_driver_client/w3c_wire_protocol_client/tesla_client_builder.ex
+++ b/lib/web_driver_client/w3c_wire_protocol_client/tesla_client_builder.ex
@@ -4,8 +4,12 @@ defmodule WebDriverClient.W3CWireProtocolClient.TeslaClientBuilder do
   alias WebDriverClient.Config
 
   @spec build_simple(Config.t()) :: Client.t()
-  def build_simple(%Config{base_url: base_url, debug?: debug?}) do
-    adapter = {Tesla.Adapter.Hackney, [recv_timeout: 30_000]}
+  def build_simple(%Config{
+        base_url: base_url,
+        debug?: debug?,
+        http_client_options: http_client_options
+      }) do
+    adapter = {Tesla.Adapter.Hackney, http_client_options}
 
     middleware =
       [

--- a/test/support/integration_testing/scenarios.ex
+++ b/test/support/integration_testing/scenarios.ex
@@ -72,7 +72,11 @@ defmodule WebDriverClient.IntegrationTesting.Scenarios do
   def get_config(%Scenario{driver: driver, protocol: protocol}) do
     driver
     |> get_base_url()
-    |> Config.build(protocol: protocol, debug: true)
+    |> Config.build(
+      protocol: protocol,
+      debug: true,
+      http_client_options: [recv_timeout: 30_000, pool: :web_driver_client_pool]
+    )
   end
 
   @spec get_start_session_payload(Scenario.t()) :: map()

--- a/test/web_driver_client/config_test.exs
+++ b/test/web_driver_client/config_test.exs
@@ -11,9 +11,19 @@ defmodule WebDriverClient.ConfigTest do
     base_url = "http://www.foo.com:8000"
     protocol = :jwp
     debug = true
+    http_client_options = [pool: :foo]
 
-    assert %Config{base_url: ^base_url, protocol: ^protocol, debug?: ^debug} =
-             Config.build(base_url, protocol: protocol, debug: debug)
+    assert %Config{
+             base_url: ^base_url,
+             protocol: ^protocol,
+             debug?: ^debug,
+             http_client_options: ^http_client_options
+           } =
+             Config.build(base_url,
+               protocol: protocol,
+               debug: debug,
+               http_client_options: http_client_options
+             )
   end
 
   test "build/1 defaults protocol to w3c" do


### PR DESCRIPTION
This PR allows the user to pass options to the underlying http client like so

```elixir
config = 
  Wallaby.Config.build("http://localhost:9515", http_client_options: [pool: :my_pool])
```
This value is passed directly to the underlying tesla adapter, which then forwards it to hackney. 

I haven't added any documentation to this option yet, because I'm not sure how much I want to couple the library's API to tesla vs just be a wrapper around tesla. I'm thinking of this as more of an escape-hatch that gives the user more flexibility for the time being.