### PR TITLE
Add hackney as dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -35,8 +35,8 @@ defmodule WebDriverClient.MixProject do
     [
       {:tesla, "~> 1.3.0"},
       {:jason, "~> 1.0"},
+      {:hackney, "~> 1.6"},
       {:bypass, "~> 1.0", only: :test},
-      {:hackney, "~> 1.6", only: [:dev, :test]},
       {:stream_data, "~> 0.1", only: [:dev, :test]},
       {:excoveralls, "~> 0.10", only: :test},
       {:credo, "~> 1.2.0", only: [:dev, :test], runtime: false},


### PR DESCRIPTION
This adds hackney as an explicit dependency. I'm considering supporting multiple HTTP clients in the future (like tesla) but for initial release, I'm thinking it will be much simpler to only support one http library.