### PR TITLE
Relax version requirement for `tesla` package

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -39,7 +39,7 @@ defmodule WebDriverClient.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:tesla, "~> 1.3.0"},
+      {:tesla, "~> 1.3"},
       {:jason, "~> 1.0"},
       {:hackney, "~> 1.6"},
       {:bypass, "~> 1.0", only: :test},


### PR DESCRIPTION
This allows current version (1.4.2)