### PR TITLE
Fix credo 1.7 strict findings

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -1,0 +1,12 @@
+%{
+  configs: [
+    %{
+      name: "default",
+      checks: %{
+        extra: [
+          {Credo.Check.Refactor.Nesting, max_nesting: 3}
+        ]
+      }
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,8 +82,6 @@ jobs:
       - run: mix format --check-formatted
         if: matrix.lockfile != 'legacy'
       - run: mix credo --strict
-        # Newer credo adds at least two checks that would require widespread changes to fix
-        if: matrix.lockfile == 'legacy'
       - name: Check for unused dependencies
         if: matrix.lockfile != 'legacy'
         run: mix deps.unlock --check-unused

--- a/lib/web_driver_client/json_wire_protocol_client.ex
+++ b/lib/web_driver_client/json_wire_protocol_client.ex
@@ -43,9 +43,8 @@ defmodule WebDriverClient.JSONWireProtocolClient do
   doc_metadata subject: :sessions
   @spec start_session(map, Config.t()) :: {:ok, Session.t()} | {:error, basic_reason}
   def start_session(payload, %Config{} = config) when is_map(payload) do
-    with {:ok, http_response} <- Commands.StartSession.send_request(config, payload),
-         {:ok, session} <- Commands.StartSession.parse_response(http_response, config) do
-      {:ok, session}
+    with {:ok, http_response} <- Commands.StartSession.send_request(config, payload) do
+      Commands.StartSession.parse_response(http_response, config)
     end
   end
 
@@ -57,9 +56,8 @@ defmodule WebDriverClient.JSONWireProtocolClient do
   doc_metadata subject: :sessions
   @spec fetch_sessions(Config.t()) :: {:ok, [Session.t()]} | {:error, basic_reason}
   def fetch_sessions(%Config{} = config) do
-    with {:ok, http_response} <- Commands.FetchSessions.send_request(config),
-         {:ok, sessions} <- Commands.FetchSessions.parse_response(http_response, config) do
-      {:ok, sessions}
+    with {:ok, http_response} <- Commands.FetchSessions.send_request(config) do
+      Commands.FetchSessions.parse_response(http_response, config)
     end
   end
 
@@ -72,9 +70,8 @@ defmodule WebDriverClient.JSONWireProtocolClient do
   @spec end_session(Session.t()) :: :ok | {:error, basic_reason}
   def end_session(%Session{id: id} = session)
       when is_session_id(id) do
-    with {:ok, http_response} <- Commands.EndSession.send_request(session),
-         :ok <- Commands.EndSession.parse_response(http_response) do
-      :ok
+    with {:ok, http_response} <- Commands.EndSession.send_request(session) do
+      Commands.EndSession.parse_response(http_response)
     end
   end
 
@@ -86,9 +83,8 @@ defmodule WebDriverClient.JSONWireProtocolClient do
   doc_metadata subject: :navigation
   @spec navigate_to(Session.t(), url) :: :ok | {:error, basic_reason}
   def navigate_to(%Session{} = session, url) when is_url(url) do
-    with {:ok, http_response} <- Commands.NavigateTo.send_request(session, url),
-         :ok <- Commands.NavigateTo.parse_response(http_response) do
-      :ok
+    with {:ok, http_response} <- Commands.NavigateTo.send_request(session, url) do
+      Commands.NavigateTo.parse_response(http_response)
     end
   end
 
@@ -100,9 +96,8 @@ defmodule WebDriverClient.JSONWireProtocolClient do
   doc_metadata subject: :navigation
   @spec fetch_current_url(Session.t()) :: {:ok, url} | {:error, basic_reason}
   def fetch_current_url(%Session{id: id} = session) when is_session_id(id) do
-    with {:ok, http_response} <- Commands.FetchCurrentURL.send_request(session),
-         {:ok, url} <- Commands.FetchCurrentURL.parse_response(http_response) do
-      {:ok, url}
+    with {:ok, http_response} <- Commands.FetchCurrentURL.send_request(session) do
+      Commands.FetchCurrentURL.parse_response(http_response)
     end
   end
 
@@ -114,9 +109,8 @@ defmodule WebDriverClient.JSONWireProtocolClient do
   doc_metadata subject: :navigation
   @spec fetch_title(Session.t()) :: {:ok, String.t()} | {:error, basic_reason}
   def fetch_title(%Session{id: id} = session) when is_session_id(id) do
-    with {:ok, http_response} <- Commands.FetchTitle.send_request(session),
-         {:ok, title} <- Commands.FetchTitle.parse_response(http_response) do
-      {:ok, title}
+    with {:ok, http_response} <- Commands.FetchTitle.send_request(session) do
+      Commands.FetchTitle.parse_response(http_response)
     end
   end
 
@@ -128,18 +122,16 @@ defmodule WebDriverClient.JSONWireProtocolClient do
   doc_metadata subject: :navigation
   @spec fetch_page_source(Session.t()) :: {:ok, String.t()} | {:error, basic_reason}
   def fetch_page_source(%Session{id: id} = session) when is_session_id(id) do
-    with {:ok, http_response} <- Commands.FetchPageSource.send_request(session),
-         {:ok, page_source} <- Commands.FetchPageSource.parse_response(http_response) do
-      {:ok, page_source}
+    with {:ok, http_response} <- Commands.FetchPageSource.send_request(session) do
+      Commands.FetchPageSource.parse_response(http_response)
     end
   end
 
   @spec fetch_window_size(Session.t()) :: {:ok, Size.t()} | {:error, basic_reason}
   def fetch_window_size(%Session{id: id} = session)
       when is_session_id(id) do
-    with {:ok, http_response} <- Commands.FetchWindowSize.send_request(session),
-         {:ok, size} <- Commands.FetchWindowSize.parse_response(http_response) do
-      {:ok, size}
+    with {:ok, http_response} <- Commands.FetchWindowSize.send_request(session) do
+      Commands.FetchWindowSize.parse_response(http_response)
     end
   end
 
@@ -148,9 +140,8 @@ defmodule WebDriverClient.JSONWireProtocolClient do
   @spec set_window_size(Session.t(), [size_opt]) :: :ok | {:error, basic_reason}
   def set_window_size(%Session{} = session, opts \\ [])
       when is_list(opts) do
-    with {:ok, http_response} <- Commands.SetWindowSize.send_request(session, opts),
-         :ok <- Commands.SetWindowSize.parse_response(http_response) do
-      :ok
+    with {:ok, http_response} <- Commands.SetWindowSize.send_request(session, opts) do
+      Commands.SetWindowSize.parse_response(http_response)
     end
   end
 
@@ -176,9 +167,8 @@ defmodule WebDriverClient.JSONWireProtocolClient do
       when is_element_location_strategy(element_location_strategy) and
              is_element_selector(element_selector) do
     with {:ok, http_response} <-
-           Commands.FindElement.send_request(session, element_location_strategy, element_selector),
-         {:ok, element} <- Commands.FindElement.parse_response(http_response) do
-      {:ok, element}
+           Commands.FindElement.send_request(session, element_location_strategy, element_selector) do
+      Commands.FindElement.parse_response(http_response)
     end
   end
 
@@ -203,9 +193,8 @@ defmodule WebDriverClient.JSONWireProtocolClient do
              session,
              element_location_strategy,
              element_selector
-           ),
-         {:ok, elements} <- Commands.FindElements.parse_response(http_response) do
-      {:ok, elements}
+           ) do
+      Commands.FindElements.parse_response(http_response)
     end
   end
 
@@ -236,9 +225,8 @@ defmodule WebDriverClient.JSONWireProtocolClient do
              element,
              element_location_strategy,
              element_selector
-           ),
-         {:ok, elements} <- Commands.FindElementsFromElement.parse_response(http_response) do
-      {:ok, elements}
+           ) do
+      Commands.FindElementsFromElement.parse_response(http_response)
     end
   end
 
@@ -251,9 +239,8 @@ defmodule WebDriverClient.JSONWireProtocolClient do
 
   @spec fetch_active_element(Session.t()) :: {:ok, Element.t()} | {:error, basic_reason}
   def fetch_active_element(%Session{} = session) do
-    with {:ok, http_response} <- Commands.FetchActiveElement.send_request(session),
-         {:ok, element} <- Commands.FetchActiveElement.parse_response(http_response) do
-      {:ok, element}
+    with {:ok, http_response} <- Commands.FetchActiveElement.send_request(session) do
+      Commands.FetchActiveElement.parse_response(http_response)
     end
   end
 
@@ -267,9 +254,8 @@ defmodule WebDriverClient.JSONWireProtocolClient do
   doc_metadata subject: :logging
   @spec fetch_log_types(Session.t()) :: {:ok, [log_type]} | {:error, basic_reason()}
   def fetch_log_types(%Session{} = session) do
-    with {:ok, http_response} <- Commands.FetchLogTypes.send_request(session),
-         {:ok, log_types} <- Commands.FetchLogTypes.parse_response(http_response) do
-      {:ok, log_types}
+    with {:ok, http_response} <- Commands.FetchLogTypes.send_request(session) do
+      Commands.FetchLogTypes.parse_response(http_response)
     end
   end
 
@@ -281,9 +267,8 @@ defmodule WebDriverClient.JSONWireProtocolClient do
   doc_metadata subject: :logging
   @spec fetch_logs(Session.t(), log_type) :: {:ok, [LogEntry.t()]} | {:error, basic_reason()}
   def fetch_logs(%Session{} = session, log_type) do
-    with {:ok, http_response} <- Commands.FetchLogs.send_request(session, log_type),
-         {:ok, log_entries} <- Commands.FetchLogs.parse_response(http_response) do
-      {:ok, log_entries}
+    with {:ok, http_response} <- Commands.FetchLogs.send_request(session, log_type) do
+      Commands.FetchLogs.parse_response(http_response)
     end
   end
 
@@ -302,9 +287,8 @@ defmodule WebDriverClient.JSONWireProtocolClient do
         %Session{} = session,
         %Element{} = element
       ) do
-    with {:ok, http_response} <- Commands.FetchElementDisplayed.send_request(session, element),
-         {:ok, boolean} <- Commands.FetchElementDisplayed.parse_response(http_response) do
-      {:ok, boolean}
+    with {:ok, http_response} <- Commands.FetchElementDisplayed.send_request(session, element) do
+      Commands.FetchElementDisplayed.parse_response(http_response)
     end
   end
 
@@ -325,9 +309,8 @@ defmodule WebDriverClient.JSONWireProtocolClient do
       )
       when is_attribute_name(attribute_name) do
     with {:ok, http_response} <-
-           Commands.FetchElementAttribute.send_request(session, element, attribute_name),
-         {:ok, boolean} <- Commands.FetchElementAttribute.parse_response(http_response) do
-      {:ok, boolean}
+           Commands.FetchElementAttribute.send_request(session, element, attribute_name) do
+      Commands.FetchElementAttribute.parse_response(http_response)
     end
   end
 
@@ -343,9 +326,8 @@ defmodule WebDriverClient.JSONWireProtocolClient do
         %Session{} = session,
         %Element{} = element
       ) do
-    with {:ok, http_response} <- Commands.FetchElementText.send_request(session, element),
-         {:ok, text} <- Commands.FetchElementText.parse_response(http_response) do
-      {:ok, text}
+    with {:ok, http_response} <- Commands.FetchElementText.send_request(session, element) do
+      Commands.FetchElementText.parse_response(http_response)
     end
   end
 
@@ -361,9 +343,8 @@ defmodule WebDriverClient.JSONWireProtocolClient do
         %Session{} = session,
         %Element{} = element
       ) do
-    with {:ok, http_response} <- Commands.ClickElement.send_request(session, element),
-         :ok <- Commands.ClickElement.parse_response(http_response) do
-      :ok
+    with {:ok, http_response} <- Commands.ClickElement.send_request(session, element) do
+      Commands.ClickElement.parse_response(http_response)
     end
   end
 
@@ -379,9 +360,8 @@ defmodule WebDriverClient.JSONWireProtocolClient do
         %Session{} = session,
         %Element{} = element
       ) do
-    with {:ok, http_response} <- Commands.ClearElement.send_request(session, element),
-         :ok <- Commands.ClearElement.parse_response(http_response) do
-      :ok
+    with {:ok, http_response} <- Commands.ClearElement.send_request(session, element) do
+      Commands.ClearElement.parse_response(http_response)
     end
   end
 
@@ -398,9 +378,8 @@ defmodule WebDriverClient.JSONWireProtocolClient do
   @spec send_keys_to_element(Session.t(), Element.t(), keys) :: :ok | {:error, basic_reason}
   def send_keys_to_element(%Session{id: id} = session, %Element{} = element, keys)
       when is_session_id(id) do
-    with {:ok, http_response} <- Commands.SendKeysToElement.send_request(session, element, keys),
-         :ok <- Commands.SendKeysToElement.parse_response(http_response) do
-      :ok
+    with {:ok, http_response} <- Commands.SendKeysToElement.send_request(session, element, keys) do
+      Commands.SendKeysToElement.parse_response(http_response)
     end
   end
 
@@ -412,9 +391,8 @@ defmodule WebDriverClient.JSONWireProtocolClient do
   @spec send_keys(Session.t(), keys) :: :ok | {:error, basic_reason}
   def send_keys(%Session{id: id} = session, keys)
       when is_session_id(id) do
-    with {:ok, http_response} <- Commands.SendKeys.send_request(session, keys),
-         :ok <- Commands.SendKeys.parse_response(http_response) do
-      :ok
+    with {:ok, http_response} <- Commands.SendKeys.send_request(session, keys) do
+      Commands.SendKeys.parse_response(http_response)
     end
   end
 
@@ -426,9 +404,8 @@ defmodule WebDriverClient.JSONWireProtocolClient do
   doc_metadata subject: :alerts
   @spec fetch_alert_text(Session.t()) :: {:ok, String.t()} | {:error, basic_reason}
   def fetch_alert_text(%Session{id: id} = session) when is_session_id(id) do
-    with {:ok, http_response} <- Commands.FetchAlertText.send_request(session),
-         {:ok, alert_text} <- Commands.FetchAlertText.parse_response(http_response) do
-      {:ok, alert_text}
+    with {:ok, http_response} <- Commands.FetchAlertText.send_request(session) do
+      Commands.FetchAlertText.parse_response(http_response)
     end
   end
 
@@ -441,9 +418,8 @@ defmodule WebDriverClient.JSONWireProtocolClient do
   @spec send_alert_text(Session.t(), String.t()) :: :ok | {:error, basic_reason}
   def send_alert_text(%Session{id: id} = session, text)
       when is_session_id(id) and is_binary(text) do
-    with {:ok, http_response} <- Commands.SendAlertText.send_request(session, text),
-         :ok <- Commands.SendAlertText.parse_response(http_response) do
-      :ok
+    with {:ok, http_response} <- Commands.SendAlertText.send_request(session, text) do
+      Commands.SendAlertText.parse_response(http_response)
     end
   end
 
@@ -455,9 +431,8 @@ defmodule WebDriverClient.JSONWireProtocolClient do
   doc_metadata subject: :alerts
   @spec accept_alert(Session.t()) :: :ok | {:error, basic_reason}
   def accept_alert(%Session{id: id} = session) when is_session_id(id) do
-    with {:ok, http_response} <- Commands.AcceptAlert.send_request(session),
-         :ok <- Commands.AcceptAlert.parse_response(http_response) do
-      :ok
+    with {:ok, http_response} <- Commands.AcceptAlert.send_request(session) do
+      Commands.AcceptAlert.parse_response(http_response)
     end
   end
 
@@ -469,9 +444,8 @@ defmodule WebDriverClient.JSONWireProtocolClient do
   doc_metadata subject: :alerts
   @spec dismiss_alert(Session.t()) :: :ok | {:error, basic_reason}
   def dismiss_alert(%Session{id: id} = session) when is_session_id(id) do
-    with {:ok, http_response} <- Commands.DismissAlert.send_request(session),
-         :ok <- Commands.DismissAlert.parse_response(http_response) do
-      :ok
+    with {:ok, http_response} <- Commands.DismissAlert.send_request(session) do
+      Commands.DismissAlert.parse_response(http_response)
     end
   end
 
@@ -482,9 +456,8 @@ defmodule WebDriverClient.JSONWireProtocolClient do
   """
   @spec take_screenshot(Session.t()) :: {:ok, binary} | {:error, basic_reason}
   def take_screenshot(%Session{id: id} = session) when is_session_id(id) do
-    with {:ok, http_response} <- Commands.TakeScreenshot.send_request(session),
-         {:ok, image_data} <- Commands.TakeScreenshot.parse_response(http_response) do
-      {:ok, image_data}
+    with {:ok, http_response} <- Commands.TakeScreenshot.send_request(session) do
+      Commands.TakeScreenshot.parse_response(http_response)
     end
   end
 
@@ -495,9 +468,8 @@ defmodule WebDriverClient.JSONWireProtocolClient do
   """
   @spec fetch_cookies(Session.t()) :: {:ok, [Cookie.t()]} | {:error, basic_reason()}
   def fetch_cookies(%Session{} = session) do
-    with {:ok, http_response} <- Commands.FetchCookies.send_request(session),
-         {:ok, cookies} <- Commands.FetchCookies.parse_response(http_response) do
-      {:ok, cookies}
+    with {:ok, http_response} <- Commands.FetchCookies.send_request(session) do
+      Commands.FetchCookies.parse_response(http_response)
     end
   end
 
@@ -512,9 +484,8 @@ defmodule WebDriverClient.JSONWireProtocolClient do
           :ok | {:error, basic_reason()}
   def set_cookie(%Session{} = session, name, value, opts \\ [])
       when is_cookie_name(name) and is_cookie_value(value) and is_list(opts) do
-    with {:ok, http_response} <- Commands.SetCookie.send_request(session, name, value, opts),
-         :ok <- Commands.SetCookie.parse_response(http_response) do
-      :ok
+    with {:ok, http_response} <- Commands.SetCookie.send_request(session, name, value, opts) do
+      Commands.SetCookie.parse_response(http_response)
     end
   end
 
@@ -525,9 +496,8 @@ defmodule WebDriverClient.JSONWireProtocolClient do
   """
   @spec delete_cookies(Session.t()) :: :ok | {:error, basic_reason}
   def delete_cookies(%Session{id: id} = session) when is_session_id(id) do
-    with {:ok, http_response} <- Commands.DeleteCookies.send_request(session),
-         :ok <- Commands.DeleteCookies.parse_response(http_response) do
-      :ok
+    with {:ok, http_response} <- Commands.DeleteCookies.send_request(session) do
+      Commands.DeleteCookies.parse_response(http_response)
     end
   end
 
@@ -538,9 +508,8 @@ defmodule WebDriverClient.JSONWireProtocolClient do
   """
   @spec fetch_server_status(Config.t()) :: {:ok, ServerStatus.t()} | {:error, basic_reason()}
   def fetch_server_status(%Config{} = config) do
-    with {:ok, http_response} <- Commands.FetchServerStatus.send_request(config),
-         {:ok, server_status} <- Commands.FetchServerStatus.parse_response(http_response) do
-      {:ok, server_status}
+    with {:ok, http_response} <- Commands.FetchServerStatus.send_request(config) do
+      Commands.FetchServerStatus.parse_response(http_response)
     end
   end
 end

--- a/lib/web_driver_client/json_wire_protocol_client/commands/accept_alert.ex
+++ b/lib/web_driver_client/json_wire_protocol_client/commands/accept_alert.ex
@@ -28,9 +28,8 @@ defmodule WebDriverClient.JSONWireProtocolClient.Commands.AcceptAlert do
   @spec parse_response(HTTPResponse.t()) ::
           :ok | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response) do
-    with {:ok, jwp_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_jwp_status(jwp_response) do
-      :ok
+    with {:ok, jwp_response} <- ResponseParser.parse_response(http_response) do
+      ResponseParser.ensure_successful_jwp_status(jwp_response)
     end
   end
 end

--- a/lib/web_driver_client/json_wire_protocol_client/commands/clear_element.ex
+++ b/lib/web_driver_client/json_wire_protocol_client/commands/clear_element.ex
@@ -34,9 +34,8 @@ defmodule WebDriverClient.JSONWireProtocolClient.Commands.ClearElement do
   @spec parse_response(HTTPResponse.t()) ::
           :ok | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response) do
-    with {:ok, jwp_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_jwp_status(jwp_response) do
-      :ok
+    with {:ok, jwp_response} <- ResponseParser.parse_response(http_response) do
+      ResponseParser.ensure_successful_jwp_status(jwp_response)
     end
   end
 end

--- a/lib/web_driver_client/json_wire_protocol_client/commands/click_element.ex
+++ b/lib/web_driver_client/json_wire_protocol_client/commands/click_element.ex
@@ -33,9 +33,8 @@ defmodule WebDriverClient.JSONWireProtocolClient.Commands.ClickElement do
   @spec parse_response(HTTPResponse.t()) ::
           :ok | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response) do
-    with {:ok, jwp_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_jwp_status(jwp_response) do
-      :ok
+    with {:ok, jwp_response} <- ResponseParser.parse_response(http_response) do
+      ResponseParser.ensure_successful_jwp_status(jwp_response)
     end
   end
 end

--- a/lib/web_driver_client/json_wire_protocol_client/commands/delete_cookies.ex
+++ b/lib/web_driver_client/json_wire_protocol_client/commands/delete_cookies.ex
@@ -26,9 +26,8 @@ defmodule WebDriverClient.JSONWireProtocolClient.Commands.DeleteCookies do
   @spec parse_response(HTTPResponse.t()) ::
           :ok | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response) do
-    with {:ok, jwp_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_jwp_status(jwp_response) do
-      :ok
+    with {:ok, jwp_response} <- ResponseParser.parse_response(http_response) do
+      ResponseParser.ensure_successful_jwp_status(jwp_response)
     end
   end
 end

--- a/lib/web_driver_client/json_wire_protocol_client/commands/dismiss_alert.ex
+++ b/lib/web_driver_client/json_wire_protocol_client/commands/dismiss_alert.ex
@@ -28,9 +28,8 @@ defmodule WebDriverClient.JSONWireProtocolClient.Commands.DismissAlert do
   @spec parse_response(HTTPResponse.t()) ::
           :ok | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response) do
-    with {:ok, jwp_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_jwp_status(jwp_response) do
-      :ok
+    with {:ok, jwp_response} <- ResponseParser.parse_response(http_response) do
+      ResponseParser.ensure_successful_jwp_status(jwp_response)
     end
   end
 end

--- a/lib/web_driver_client/json_wire_protocol_client/commands/end_session.ex
+++ b/lib/web_driver_client/json_wire_protocol_client/commands/end_session.ex
@@ -26,9 +26,8 @@ defmodule WebDriverClient.JSONWireProtocolClient.Commands.EndSession do
   @spec parse_response(HTTPResponse.t()) ::
           :ok | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response) do
-    with {:ok, jwp_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_jwp_status(jwp_response) do
-      :ok
+    with {:ok, jwp_response} <- ResponseParser.parse_response(http_response) do
+      ResponseParser.ensure_successful_jwp_status(jwp_response)
     end
   end
 end

--- a/lib/web_driver_client/json_wire_protocol_client/commands/fetch_active_element.ex
+++ b/lib/web_driver_client/json_wire_protocol_client/commands/fetch_active_element.ex
@@ -30,9 +30,8 @@ defmodule WebDriverClient.JSONWireProtocolClient.Commands.FetchActiveElement do
           {:ok, Element.t()} | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response) do
     with {:ok, jwp_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_jwp_status(jwp_response),
-         {:ok, element} <- ResponseParser.parse_element(jwp_response) do
-      {:ok, element}
+         :ok <- ResponseParser.ensure_successful_jwp_status(jwp_response) do
+      ResponseParser.parse_element(jwp_response)
     end
   end
 end

--- a/lib/web_driver_client/json_wire_protocol_client/commands/fetch_alert_text.ex
+++ b/lib/web_driver_client/json_wire_protocol_client/commands/fetch_alert_text.ex
@@ -29,9 +29,8 @@ defmodule WebDriverClient.JSONWireProtocolClient.Commands.FetchAlertText do
           {:ok, String.t()} | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response) do
     with {:ok, jwp_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_jwp_status(jwp_response),
-         {:ok, value} <- ResponseParser.parse_value(jwp_response) do
-      {:ok, value}
+         :ok <- ResponseParser.ensure_successful_jwp_status(jwp_response) do
+      ResponseParser.parse_value(jwp_response)
     end
   end
 end

--- a/lib/web_driver_client/json_wire_protocol_client/commands/fetch_cookies.ex
+++ b/lib/web_driver_client/json_wire_protocol_client/commands/fetch_cookies.ex
@@ -29,9 +29,8 @@ defmodule WebDriverClient.JSONWireProtocolClient.Commands.FetchCookies do
           {:ok, [Cookie.t()]} | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response) do
     with {:ok, jwp_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_jwp_status(jwp_response),
-         {:ok, cookies} <- ResponseParser.parse_cookies(jwp_response) do
-      {:ok, cookies}
+         :ok <- ResponseParser.ensure_successful_jwp_status(jwp_response) do
+      ResponseParser.parse_cookies(jwp_response)
     end
   end
 end

--- a/lib/web_driver_client/json_wire_protocol_client/commands/fetch_current_url.ex
+++ b/lib/web_driver_client/json_wire_protocol_client/commands/fetch_current_url.ex
@@ -32,9 +32,8 @@ defmodule WebDriverClient.JSONWireProtocolClient.Commands.FetchCurrentURL do
           {:ok, url} | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response) do
     with {:ok, jwp_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_jwp_status(jwp_response),
-         {:ok, url} <- ResponseParser.parse_url(jwp_response) do
-      {:ok, url}
+         :ok <- ResponseParser.ensure_successful_jwp_status(jwp_response) do
+      ResponseParser.parse_url(jwp_response)
     end
   end
 end

--- a/lib/web_driver_client/json_wire_protocol_client/commands/fetch_element_attribute.ex
+++ b/lib/web_driver_client/json_wire_protocol_client/commands/fetch_element_attribute.ex
@@ -38,9 +38,8 @@ defmodule WebDriverClient.JSONWireProtocolClient.Commands.FetchElementAttribute 
           {:ok, String.t()} | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response) do
     with {:ok, jwp_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_jwp_status(jwp_response),
-         {:ok, value} <- ResponseParser.parse_value(jwp_response) do
-      {:ok, value}
+         :ok <- ResponseParser.ensure_successful_jwp_status(jwp_response) do
+      ResponseParser.parse_value(jwp_response)
     end
   end
 end

--- a/lib/web_driver_client/json_wire_protocol_client/commands/fetch_element_displayed.ex
+++ b/lib/web_driver_client/json_wire_protocol_client/commands/fetch_element_displayed.ex
@@ -33,9 +33,8 @@ defmodule WebDriverClient.JSONWireProtocolClient.Commands.FetchElementDisplayed 
           {:ok, boolean} | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response) do
     with {:ok, jwp_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_jwp_status(jwp_response),
-         {:ok, boolean} <- ResponseParser.parse_boolean(jwp_response) do
-      {:ok, boolean}
+         :ok <- ResponseParser.ensure_successful_jwp_status(jwp_response) do
+      ResponseParser.parse_boolean(jwp_response)
     end
   end
 end

--- a/lib/web_driver_client/json_wire_protocol_client/commands/fetch_element_text.ex
+++ b/lib/web_driver_client/json_wire_protocol_client/commands/fetch_element_text.ex
@@ -33,9 +33,8 @@ defmodule WebDriverClient.JSONWireProtocolClient.Commands.FetchElementText do
           {:ok, String.t()} | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response) do
     with {:ok, jwp_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_jwp_status(jwp_response),
-         {:ok, text} <- ResponseParser.parse_value(jwp_response) do
-      {:ok, text}
+         :ok <- ResponseParser.ensure_successful_jwp_status(jwp_response) do
+      ResponseParser.parse_value(jwp_response)
     end
   end
 end

--- a/lib/web_driver_client/json_wire_protocol_client/commands/fetch_log_types.ex
+++ b/lib/web_driver_client/json_wire_protocol_client/commands/fetch_log_types.ex
@@ -31,9 +31,8 @@ defmodule WebDriverClient.JSONWireProtocolClient.Commands.FetchLogTypes do
           {:ok, [log_type]} | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response) do
     with {:ok, jwp_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_jwp_status(jwp_response),
-         {:ok, log_types} <- ResponseParser.parse_value(jwp_response) do
-      {:ok, log_types}
+         :ok <- ResponseParser.ensure_successful_jwp_status(jwp_response) do
+      ResponseParser.parse_value(jwp_response)
     end
   end
 end

--- a/lib/web_driver_client/json_wire_protocol_client/commands/fetch_logs.ex
+++ b/lib/web_driver_client/json_wire_protocol_client/commands/fetch_logs.ex
@@ -37,9 +37,8 @@ defmodule WebDriverClient.JSONWireProtocolClient.Commands.FetchLogs do
           {:ok, [LogEntry.t()]} | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response) do
     with {:ok, jwp_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_jwp_status(jwp_response),
-         {:ok, log_entries} <- ResponseParser.parse_log_entries(jwp_response) do
-      {:ok, log_entries}
+         :ok <- ResponseParser.ensure_successful_jwp_status(jwp_response) do
+      ResponseParser.parse_log_entries(jwp_response)
     end
   end
 end

--- a/lib/web_driver_client/json_wire_protocol_client/commands/fetch_page_source.ex
+++ b/lib/web_driver_client/json_wire_protocol_client/commands/fetch_page_source.ex
@@ -31,9 +31,8 @@ defmodule WebDriverClient.JSONWireProtocolClient.Commands.FetchPageSource do
           {:ok, page_source} | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response) do
     with {:ok, jwp_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_jwp_status(jwp_response),
-         {:ok, title} <- ResponseParser.parse_value(jwp_response) do
-      {:ok, title}
+         :ok <- ResponseParser.ensure_successful_jwp_status(jwp_response) do
+      ResponseParser.parse_value(jwp_response)
     end
   end
 end

--- a/lib/web_driver_client/json_wire_protocol_client/commands/fetch_sessions.ex
+++ b/lib/web_driver_client/json_wire_protocol_client/commands/fetch_sessions.ex
@@ -27,9 +27,8 @@ defmodule WebDriverClient.JSONWireProtocolClient.Commands.FetchSessions do
           {:ok, [Session.t()]} | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response, %Config{} = config) do
     with {:ok, jwp_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_jwp_status(jwp_response),
-         {:ok, sessions} <- ResponseParser.parse_fetch_sessions_response(jwp_response, config) do
-      {:ok, sessions}
+         :ok <- ResponseParser.ensure_successful_jwp_status(jwp_response) do
+      ResponseParser.parse_fetch_sessions_response(jwp_response, config)
     end
   end
 end

--- a/lib/web_driver_client/json_wire_protocol_client/commands/fetch_title.ex
+++ b/lib/web_driver_client/json_wire_protocol_client/commands/fetch_title.ex
@@ -31,9 +31,8 @@ defmodule WebDriverClient.JSONWireProtocolClient.Commands.FetchTitle do
           {:ok, title} | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response) do
     with {:ok, jwp_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_jwp_status(jwp_response),
-         {:ok, title} <- ResponseParser.parse_value(jwp_response) do
-      {:ok, title}
+         :ok <- ResponseParser.ensure_successful_jwp_status(jwp_response) do
+      ResponseParser.parse_value(jwp_response)
     end
   end
 end

--- a/lib/web_driver_client/json_wire_protocol_client/commands/fetch_window_size.ex
+++ b/lib/web_driver_client/json_wire_protocol_client/commands/fetch_window_size.ex
@@ -31,9 +31,8 @@ defmodule WebDriverClient.JSONWireProtocolClient.Commands.FetchWindowSize do
           {:ok, Size.t()} | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response) do
     with {:ok, jwp_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_jwp_status(jwp_response),
-         {:ok, size} <- ResponseParser.parse_size(jwp_response) do
-      {:ok, size}
+         :ok <- ResponseParser.ensure_successful_jwp_status(jwp_response) do
+      ResponseParser.parse_size(jwp_response)
     end
   end
 end

--- a/lib/web_driver_client/json_wire_protocol_client/commands/find_element.ex
+++ b/lib/web_driver_client/json_wire_protocol_client/commands/find_element.ex
@@ -46,9 +46,8 @@ defmodule WebDriverClient.JSONWireProtocolClient.Commands.FindElement do
           {:ok, Element.t()} | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response) do
     with {:ok, jwp_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_jwp_status(jwp_response),
-         {:ok, element} <- ResponseParser.parse_element(jwp_response) do
-      {:ok, element}
+         :ok <- ResponseParser.ensure_successful_jwp_status(jwp_response) do
+      ResponseParser.parse_element(jwp_response)
     end
   end
 

--- a/lib/web_driver_client/json_wire_protocol_client/commands/find_elements.ex
+++ b/lib/web_driver_client/json_wire_protocol_client/commands/find_elements.ex
@@ -47,9 +47,8 @@ defmodule WebDriverClient.JSONWireProtocolClient.Commands.FindElements do
           {:ok, [Element.t()]} | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response) do
     with {:ok, jwp_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_jwp_status(jwp_response),
-         {:ok, element} <- ResponseParser.parse_elements(jwp_response) do
-      {:ok, element}
+         :ok <- ResponseParser.ensure_successful_jwp_status(jwp_response) do
+      ResponseParser.parse_elements(jwp_response)
     end
   end
 

--- a/lib/web_driver_client/json_wire_protocol_client/commands/find_elements_from_element.ex
+++ b/lib/web_driver_client/json_wire_protocol_client/commands/find_elements_from_element.ex
@@ -48,9 +48,8 @@ defmodule WebDriverClient.JSONWireProtocolClient.Commands.FindElementsFromElemen
           {:ok, [Element.t()]} | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response) do
     with {:ok, jwp_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_jwp_status(jwp_response),
-         {:ok, element} <- ResponseParser.parse_elements(jwp_response) do
-      {:ok, element}
+         :ok <- ResponseParser.ensure_successful_jwp_status(jwp_response) do
+      ResponseParser.parse_elements(jwp_response)
     end
   end
 

--- a/lib/web_driver_client/json_wire_protocol_client/commands/navigate_to.ex
+++ b/lib/web_driver_client/json_wire_protocol_client/commands/navigate_to.ex
@@ -29,9 +29,8 @@ defmodule WebDriverClient.JSONWireProtocolClient.Commands.NavigateTo do
   @spec parse_response(HTTPResponse.t()) ::
           :ok | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response) do
-    with {:ok, jwp_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_jwp_status(jwp_response) do
-      :ok
+    with {:ok, jwp_response} <- ResponseParser.parse_response(http_response) do
+      ResponseParser.ensure_successful_jwp_status(jwp_response)
     end
   end
 end

--- a/lib/web_driver_client/json_wire_protocol_client/commands/send_alert_text.ex
+++ b/lib/web_driver_client/json_wire_protocol_client/commands/send_alert_text.ex
@@ -30,9 +30,8 @@ defmodule WebDriverClient.JSONWireProtocolClient.Commands.SendAlertText do
   @spec parse_response(HTTPResponse.t()) ::
           :ok | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response) do
-    with {:ok, jwp_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_jwp_status(jwp_response) do
-      :ok
+    with {:ok, jwp_response} <- ResponseParser.parse_response(http_response) do
+      ResponseParser.ensure_successful_jwp_status(jwp_response)
     end
   end
 end

--- a/lib/web_driver_client/json_wire_protocol_client/commands/send_keys.ex
+++ b/lib/web_driver_client/json_wire_protocol_client/commands/send_keys.ex
@@ -34,9 +34,8 @@ defmodule WebDriverClient.JSONWireProtocolClient.Commands.SendKeys do
   @spec parse_response(HTTPResponse.t()) ::
           :ok | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response) do
-    with {:ok, jwp_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_jwp_status(jwp_response) do
-      :ok
+    with {:ok, jwp_response} <- ResponseParser.parse_response(http_response) do
+      ResponseParser.ensure_successful_jwp_status(jwp_response)
     end
   end
 

--- a/lib/web_driver_client/json_wire_protocol_client/commands/send_keys_to_element.ex
+++ b/lib/web_driver_client/json_wire_protocol_client/commands/send_keys_to_element.ex
@@ -36,9 +36,8 @@ defmodule WebDriverClient.JSONWireProtocolClient.Commands.SendKeysToElement do
   @spec parse_response(HTTPResponse.t()) ::
           :ok | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response) do
-    with {:ok, jwp_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_jwp_status(jwp_response) do
-      :ok
+    with {:ok, jwp_response} <- ResponseParser.parse_response(http_response) do
+      ResponseParser.ensure_successful_jwp_status(jwp_response)
     end
   end
 

--- a/lib/web_driver_client/json_wire_protocol_client/commands/set_cookie.ex
+++ b/lib/web_driver_client/json_wire_protocol_client/commands/set_cookie.ex
@@ -40,9 +40,8 @@ defmodule WebDriverClient.JSONWireProtocolClient.Commands.SetCookie do
   @spec parse_response(HTTPResponse.t()) ::
           :ok | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response) do
-    with {:ok, jwp_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_jwp_status(jwp_response) do
-      :ok
+    with {:ok, jwp_response} <- ResponseParser.parse_response(http_response) do
+      ResponseParser.ensure_successful_jwp_status(jwp_response)
     end
   end
 end

--- a/lib/web_driver_client/json_wire_protocol_client/commands/set_window_size.ex
+++ b/lib/web_driver_client/json_wire_protocol_client/commands/set_window_size.ex
@@ -33,9 +33,8 @@ defmodule WebDriverClient.JSONWireProtocolClient.Commands.SetWindowSize do
   @spec parse_response(HTTPResponse.t()) ::
           :ok | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response) do
-    with {:ok, jwp_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_jwp_status(jwp_response) do
-      :ok
+    with {:ok, jwp_response} <- ResponseParser.parse_response(http_response) do
+      ResponseParser.ensure_successful_jwp_status(jwp_response)
     end
   end
 end

--- a/lib/web_driver_client/json_wire_protocol_client/commands/start_session.ex
+++ b/lib/web_driver_client/json_wire_protocol_client/commands/start_session.ex
@@ -27,9 +27,8 @@ defmodule WebDriverClient.JSONWireProtocolClient.Commands.StartSession do
           {:ok, Session.t()} | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response, %Config{} = config) do
     with {:ok, jwp_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_jwp_status(jwp_response),
-         {:ok, session} <- ResponseParser.parse_start_session_response(jwp_response, config) do
-      {:ok, session}
+         :ok <- ResponseParser.ensure_successful_jwp_status(jwp_response) do
+      ResponseParser.parse_start_session_response(jwp_response, config)
     end
   end
 end

--- a/lib/web_driver_client/json_wire_protocol_client/commands/take_screenshot.ex
+++ b/lib/web_driver_client/json_wire_protocol_client/commands/take_screenshot.ex
@@ -29,9 +29,8 @@ defmodule WebDriverClient.JSONWireProtocolClient.Commands.TakeScreenshot do
           {:ok, binary} | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response) do
     with {:ok, jwp_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_jwp_status(jwp_response),
-         {:ok, image_data} <- ResponseParser.parse_image_data(jwp_response) do
-      {:ok, image_data}
+         :ok <- ResponseParser.ensure_successful_jwp_status(jwp_response) do
+      ResponseParser.parse_image_data(jwp_response)
     end
   end
 end

--- a/lib/web_driver_client/w3c_wire_protocol_client.ex
+++ b/lib/web_driver_client/w3c_wire_protocol_client.ex
@@ -44,9 +44,8 @@ defmodule WebDriverClient.W3CWireProtocolClient do
   doc_metadata subject: :sessions
   @spec start_session(map, Config.t()) :: {:ok, Session.t()} | {:error, basic_reason}
   def start_session(payload, %Config{} = config) when is_map(payload) do
-    with {:ok, http_response} <- Commands.StartSession.send_request(config, payload),
-         {:ok, session} <- Commands.StartSession.parse_response(http_response, config) do
-      {:ok, session}
+    with {:ok, http_response} <- Commands.StartSession.send_request(config, payload) do
+      Commands.StartSession.parse_response(http_response, config)
     end
   end
 
@@ -58,9 +57,8 @@ defmodule WebDriverClient.W3CWireProtocolClient do
   doc_metadata subject: :sessions
   @spec fetch_sessions(Config.t()) :: {:ok, [Session.t()]} | {:error, basic_reason}
   def fetch_sessions(%Config{} = config) do
-    with {:ok, http_response} <- Commands.FetchSessions.send_request(config),
-         {:ok, sessions} <- Commands.FetchSessions.parse_response(http_response, config) do
-      {:ok, sessions}
+    with {:ok, http_response} <- Commands.FetchSessions.send_request(config) do
+      Commands.FetchSessions.parse_response(http_response, config)
     end
   end
 
@@ -72,9 +70,8 @@ defmodule WebDriverClient.W3CWireProtocolClient do
   doc_metadata subject: :sessions
   @spec end_session(Session.t()) :: :ok | {:error, basic_reason}
   def end_session(%Session{id: id} = session) when is_session_id(id) do
-    with {:ok, http_response} <- Commands.EndSession.send_request(session),
-         :ok <- Commands.EndSession.parse_response(http_response) do
-      :ok
+    with {:ok, http_response} <- Commands.EndSession.send_request(session) do
+      Commands.EndSession.parse_response(http_response)
     end
   end
 
@@ -86,9 +83,8 @@ defmodule WebDriverClient.W3CWireProtocolClient do
   doc_metadata subject: :navigation
   @spec navigate_to(Session.t(), url) :: :ok | {:error, basic_reason}
   def navigate_to(%Session{} = session, url) when is_url(url) do
-    with {:ok, http_response} <- Commands.NavigateTo.send_request(session, url),
-         :ok <- Commands.NavigateTo.parse_response(http_response) do
-      :ok
+    with {:ok, http_response} <- Commands.NavigateTo.send_request(session, url) do
+      Commands.NavigateTo.parse_response(http_response)
     end
   end
 
@@ -100,9 +96,8 @@ defmodule WebDriverClient.W3CWireProtocolClient do
   doc_metadata subject: :navigation
   @spec fetch_current_url(Session.t()) :: {:ok, url} | {:error, basic_reason}
   def fetch_current_url(%Session{id: id} = session) when is_session_id(id) do
-    with {:ok, http_response} <- Commands.FetchCurrentURL.send_request(session),
-         {:ok, url} <- Commands.FetchCurrentURL.parse_response(http_response) do
-      {:ok, url}
+    with {:ok, http_response} <- Commands.FetchCurrentURL.send_request(session) do
+      Commands.FetchCurrentURL.parse_response(http_response)
     end
   end
 
@@ -114,9 +109,8 @@ defmodule WebDriverClient.W3CWireProtocolClient do
   doc_metadata subject: :navigation
   @spec fetch_title(Session.t()) :: {:ok, String.t()} | {:error, basic_reason}
   def fetch_title(%Session{id: id} = session) when is_session_id(id) do
-    with {:ok, http_response} <- Commands.FetchTitle.send_request(session),
-         {:ok, title} <- Commands.FetchTitle.parse_response(http_response) do
-      {:ok, title}
+    with {:ok, http_response} <- Commands.FetchTitle.send_request(session) do
+      Commands.FetchTitle.parse_response(http_response)
     end
   end
 
@@ -128,17 +122,15 @@ defmodule WebDriverClient.W3CWireProtocolClient do
   doc_metadata subject: :navigation
   @spec fetch_page_source(Session.t()) :: {:ok, String.t()} | {:error, basic_reason}
   def fetch_page_source(%Session{id: id} = session) when is_session_id(id) do
-    with {:ok, http_response} <- Commands.FetchPageSource.send_request(session),
-         {:ok, page_source} <- Commands.FetchPageSource.parse_response(http_response) do
-      {:ok, page_source}
+    with {:ok, http_response} <- Commands.FetchPageSource.send_request(session) do
+      Commands.FetchPageSource.parse_response(http_response)
     end
   end
 
   @spec fetch_window_rect(Session.t()) :: {:ok, Rect.t()} | {:error, basic_reason}
   def fetch_window_rect(%Session{id: id} = session) when is_session_id(id) do
-    with {:ok, http_response} <- Commands.FetchWindowRect.send_request(session),
-         {:ok, url} <- Commands.FetchWindowRect.parse_response(http_response) do
-      {:ok, url}
+    with {:ok, http_response} <- Commands.FetchWindowRect.send_request(session) do
+      Commands.FetchWindowRect.parse_response(http_response)
     end
   end
 
@@ -147,9 +139,8 @@ defmodule WebDriverClient.W3CWireProtocolClient do
   @spec set_window_rect(Session.t(), [rect_opt]) :: :ok | {:error, basic_reason}
   def set_window_rect(%Session{} = session, opts \\ [])
       when is_list(opts) do
-    with {:ok, http_response} <- Commands.SetWindowRect.send_request(session, opts),
-         :ok <- Commands.SetWindowRect.parse_response(http_response) do
-      :ok
+    with {:ok, http_response} <- Commands.SetWindowRect.send_request(session, opts) do
+      Commands.SetWindowRect.parse_response(http_response)
     end
   end
 
@@ -158,9 +149,8 @@ defmodule WebDriverClient.W3CWireProtocolClient do
   doc_metadata subject: :logging
   @spec fetch_log_types(Session.t()) :: {:ok, [log_type]} | {:error, basic_reason()}
   def fetch_log_types(%Session{} = session) do
-    with {:ok, http_response} <- Commands.FetchLogTypes.send_request(session),
-         {:ok, log_types} <- Commands.FetchLogTypes.parse_response(http_response) do
-      {:ok, log_types}
+    with {:ok, http_response} <- Commands.FetchLogTypes.send_request(session) do
+      Commands.FetchLogTypes.parse_response(http_response)
     end
   end
 
@@ -173,9 +163,8 @@ defmodule WebDriverClient.W3CWireProtocolClient do
   doc_metadata subject: :logging
   @spec fetch_logs(Session.t(), log_type) :: {:ok, [LogEntry.t()]} | {:error, basic_reason()}
   def fetch_logs(%Session{} = session, log_type) do
-    with {:ok, http_response} <- Commands.FetchLogs.send_request(session, log_type),
-         {:ok, log_entries} <- Commands.FetchLogs.parse_response(http_response) do
-      {:ok, log_entries}
+    with {:ok, http_response} <- Commands.FetchLogs.send_request(session, log_type) do
+      Commands.FetchLogs.parse_response(http_response)
     end
   end
 
@@ -205,9 +194,8 @@ defmodule WebDriverClient.W3CWireProtocolClient do
              session,
              element_location_strategy,
              element_selector
-           ),
-         {:ok, element} <- Commands.FindElement.parse_response(http_response) do
-      {:ok, element}
+           ) do
+      Commands.FindElement.parse_response(http_response)
     end
   end
 
@@ -232,9 +220,8 @@ defmodule WebDriverClient.W3CWireProtocolClient do
              session,
              element_location_strategy,
              element_selector
-           ),
-         {:ok, elements} <- Commands.FindElements.parse_response(http_response) do
-      {:ok, elements}
+           ) do
+      Commands.FindElements.parse_response(http_response)
     end
   end
 
@@ -265,9 +252,8 @@ defmodule WebDriverClient.W3CWireProtocolClient do
              element,
              element_location_strategy,
              element_selector
-           ),
-         {:ok, elements} <- Commands.FindElementsFromElement.parse_response(http_response) do
-      {:ok, elements}
+           ) do
+      Commands.FindElementsFromElement.parse_response(http_response)
     end
   end
 
@@ -280,9 +266,8 @@ defmodule WebDriverClient.W3CWireProtocolClient do
 
   @spec fetch_active_element(Session.t()) :: {:ok, Element.t()} | {:error, basic_reason}
   def fetch_active_element(%Session{} = session) do
-    with {:ok, http_response} <- Commands.FetchActiveElement.send_request(session),
-         {:ok, element} <- Commands.FetchActiveElement.parse_response(http_response) do
-      {:ok, element}
+    with {:ok, http_response} <- Commands.FetchActiveElement.send_request(session) do
+      Commands.FetchActiveElement.parse_response(http_response)
     end
   end
 
@@ -298,9 +283,8 @@ defmodule WebDriverClient.W3CWireProtocolClient do
           {:ok, boolean} | {:error, basic_reason}
 
   def fetch_element_displayed(%Session{} = session, %Element{} = element) do
-    with {:ok, http_response} <- Commands.FetchElementDisplayed.send_request(session, element),
-         {:ok, boolean} <- Commands.FetchElementDisplayed.parse_response(http_response) do
-      {:ok, boolean}
+    with {:ok, http_response} <- Commands.FetchElementDisplayed.send_request(session, element) do
+      Commands.FetchElementDisplayed.parse_response(http_response)
     end
   end
 
@@ -317,9 +301,8 @@ defmodule WebDriverClient.W3CWireProtocolClient do
   def fetch_element_attribute(%Session{} = session, %Element{} = element, attribute_name)
       when is_attribute_name(attribute_name) do
     with {:ok, http_response} <-
-           Commands.FetchElementAttribute.send_request(session, element, attribute_name),
-         {:ok, value} <- Commands.FetchElementAttribute.parse_response(http_response) do
-      {:ok, value}
+           Commands.FetchElementAttribute.send_request(session, element, attribute_name) do
+      Commands.FetchElementAttribute.parse_response(http_response)
     end
   end
 
@@ -336,9 +319,8 @@ defmodule WebDriverClient.W3CWireProtocolClient do
   def fetch_element_property(%Session{} = session, %Element{} = element, property_name)
       when is_property_name(property_name) do
     with {:ok, http_response} <-
-           Commands.FetchElementProperty.send_request(session, element, property_name),
-         {:ok, value} <- Commands.FetchElementProperty.parse_response(http_response) do
-      {:ok, value}
+           Commands.FetchElementProperty.send_request(session, element, property_name) do
+      Commands.FetchElementProperty.parse_response(http_response)
     end
   end
 
@@ -351,9 +333,8 @@ defmodule WebDriverClient.W3CWireProtocolClient do
 
   @spec fetch_element_text(Session.t(), Element.t()) :: {:ok, String.t()} | {:error, basic_reason}
   def fetch_element_text(%Session{} = session, %Element{} = element) do
-    with {:ok, http_response} <- Commands.FetchElementText.send_request(session, element),
-         {:ok, value} <- Commands.FetchElementText.parse_response(http_response) do
-      {:ok, value}
+    with {:ok, http_response} <- Commands.FetchElementText.send_request(session, element) do
+      Commands.FetchElementText.parse_response(http_response)
     end
   end
 
@@ -366,9 +347,8 @@ defmodule WebDriverClient.W3CWireProtocolClient do
 
   @spec click_element(Session.t(), Element.t()) :: :ok | {:error, basic_reason}
   def click_element(%Session{} = session, %Element{} = element) do
-    with {:ok, http_response} <- Commands.ClickElement.send_request(session, element),
-         :ok <- Commands.ClickElement.parse_response(http_response) do
-      :ok
+    with {:ok, http_response} <- Commands.ClickElement.send_request(session, element) do
+      Commands.ClickElement.parse_response(http_response)
     end
   end
 
@@ -381,9 +361,8 @@ defmodule WebDriverClient.W3CWireProtocolClient do
 
   @spec clear_element(Session.t(), Element.t()) :: :ok | {:error, basic_reason}
   def clear_element(%Session{} = session, %Element{} = element) do
-    with {:ok, http_response} <- Commands.ClearElement.send_request(session, element),
-         :ok <- Commands.ClearElement.parse_response(http_response) do
-      :ok
+    with {:ok, http_response} <- Commands.ClearElement.send_request(session, element) do
+      Commands.ClearElement.parse_response(http_response)
     end
   end
 
@@ -400,9 +379,8 @@ defmodule WebDriverClient.W3CWireProtocolClient do
 
   @spec send_keys_to_element(Session.t(), Element.t(), keys) :: :ok | {:error, basic_reason}
   def send_keys_to_element(%Session{} = session, %Element{} = element, keys) do
-    with {:ok, http_response} <- Commands.SendKeysToElement.send_request(session, element, keys),
-         :ok <- Commands.SendKeysToElement.parse_response(http_response) do
-      :ok
+    with {:ok, http_response} <- Commands.SendKeysToElement.send_request(session, element, keys) do
+      Commands.SendKeysToElement.parse_response(http_response)
     end
   end
 
@@ -414,9 +392,8 @@ defmodule WebDriverClient.W3CWireProtocolClient do
   doc_metadata subject: :alerts
   @spec fetch_alert_text(Session.t()) :: {:ok, String.t()} | {:error, basic_reason}
   def fetch_alert_text(%Session{id: id} = session) when is_session_id(id) do
-    with {:ok, http_response} <- Commands.FetchAlertText.send_request(session),
-         {:ok, alert_text} <- Commands.FetchAlertText.parse_response(http_response) do
-      {:ok, alert_text}
+    with {:ok, http_response} <- Commands.FetchAlertText.send_request(session) do
+      Commands.FetchAlertText.parse_response(http_response)
     end
   end
 
@@ -429,9 +406,8 @@ defmodule WebDriverClient.W3CWireProtocolClient do
   @spec send_alert_text(Session.t(), String.t()) :: {:ok, String.t()} | {:error, basic_reason}
   def send_alert_text(%Session{id: id} = session, text)
       when is_session_id(id) and is_binary(text) do
-    with {:ok, http_response} <- Commands.SendAlertText.send_request(session, text),
-         :ok <- Commands.SendAlertText.parse_response(http_response) do
-      :ok
+    with {:ok, http_response} <- Commands.SendAlertText.send_request(session, text) do
+      Commands.SendAlertText.parse_response(http_response)
     end
   end
 
@@ -443,9 +419,8 @@ defmodule WebDriverClient.W3CWireProtocolClient do
   doc_metadata subject: :alerts
   @spec accept_alert(Session.t()) :: :ok | {:error, basic_reason}
   def accept_alert(%Session{id: id} = session) when is_session_id(id) do
-    with {:ok, http_response} <- Commands.AcceptAlert.send_request(session),
-         :ok <- Commands.AcceptAlert.parse_response(http_response) do
-      :ok
+    with {:ok, http_response} <- Commands.AcceptAlert.send_request(session) do
+      Commands.AcceptAlert.parse_response(http_response)
     end
   end
 
@@ -457,9 +432,8 @@ defmodule WebDriverClient.W3CWireProtocolClient do
   doc_metadata subject: :alerts
   @spec dismiss_alert(Session.t()) :: :ok | {:error, basic_reason}
   def dismiss_alert(%Session{id: id} = session) when is_session_id(id) do
-    with {:ok, http_response} <- Commands.DismissAlert.send_request(session),
-         :ok <- Commands.DismissAlert.parse_response(http_response) do
-      :ok
+    with {:ok, http_response} <- Commands.DismissAlert.send_request(session) do
+      Commands.DismissAlert.parse_response(http_response)
     end
   end
 
@@ -470,9 +444,8 @@ defmodule WebDriverClient.W3CWireProtocolClient do
   """
   @spec take_screenshot(Session.t()) :: {:ok, binary} | {:error, basic_reason}
   def take_screenshot(%Session{id: id} = session) when is_session_id(id) do
-    with {:ok, http_response} <- Commands.TakeScreenshot.send_request(session),
-         {:ok, image_data} <- Commands.TakeScreenshot.parse_response(http_response) do
-      {:ok, image_data}
+    with {:ok, http_response} <- Commands.TakeScreenshot.send_request(session) do
+      Commands.TakeScreenshot.parse_response(http_response)
     end
   end
 
@@ -483,9 +456,8 @@ defmodule WebDriverClient.W3CWireProtocolClient do
   """
   @spec fetch_cookies(Session.t()) :: {:ok, [Cookie.t()]} | {:error, basic_reason()}
   def fetch_cookies(%Session{} = session) do
-    with {:ok, http_response} <- Commands.FetchCookies.send_request(session),
-         {:ok, cookies} <- Commands.FetchCookies.parse_response(http_response) do
-      {:ok, cookies}
+    with {:ok, http_response} <- Commands.FetchCookies.send_request(session) do
+      Commands.FetchCookies.parse_response(http_response)
     end
   end
 
@@ -500,9 +472,8 @@ defmodule WebDriverClient.W3CWireProtocolClient do
           :ok | {:error, basic_reason}
   def set_cookie(%Session{id: id} = session, name, value, opts \\ [])
       when is_session_id(id) and is_cookie_name(name) and is_cookie_value(value) and is_list(opts) do
-    with {:ok, http_response} <- Commands.SetCookie.send_request(session, name, value, opts),
-         :ok <- Commands.SetCookie.parse_response(http_response) do
-      :ok
+    with {:ok, http_response} <- Commands.SetCookie.send_request(session, name, value, opts) do
+      Commands.SetCookie.parse_response(http_response)
     end
   end
 
@@ -513,9 +484,8 @@ defmodule WebDriverClient.W3CWireProtocolClient do
   """
   @spec delete_cookies(Session.t()) :: :ok | {:error, basic_reason}
   def delete_cookies(%Session{id: id} = session) when is_session_id(id) do
-    with {:ok, http_response} <- Commands.DeleteCookies.send_request(session),
-         :ok <- Commands.DeleteCookies.parse_response(http_response) do
-      :ok
+    with {:ok, http_response} <- Commands.DeleteCookies.send_request(session) do
+      Commands.DeleteCookies.parse_response(http_response)
     end
   end
 
@@ -526,9 +496,8 @@ defmodule WebDriverClient.W3CWireProtocolClient do
   """
   @spec fetch_server_status(Config.t()) :: {:ok, ServerStatus.t()} | {:error, basic_reason()}
   def fetch_server_status(%Config{} = config) do
-    with {:ok, http_response} <- Commands.FetchServerStatus.send_request(config),
-         {:ok, server_status} <- Commands.FetchServerStatus.parse_response(http_response) do
-      {:ok, server_status}
+    with {:ok, http_response} <- Commands.FetchServerStatus.send_request(config) do
+      Commands.FetchServerStatus.parse_response(http_response)
     end
   end
 end

--- a/lib/web_driver_client/w3c_wire_protocol_client/commands/accept_alert.ex
+++ b/lib/web_driver_client/w3c_wire_protocol_client/commands/accept_alert.ex
@@ -30,9 +30,8 @@ defmodule WebDriverClient.W3CWireProtocolClient.Commands.AcceptAlert do
   @spec parse_response(HTTPResponse.t()) ::
           :ok | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response) do
-    with {:ok, w3c_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_response(w3c_response) do
-      :ok
+    with {:ok, w3c_response} <- ResponseParser.parse_response(http_response) do
+      ResponseParser.ensure_successful_response(w3c_response)
     end
   end
 end

--- a/lib/web_driver_client/w3c_wire_protocol_client/commands/clear_element.ex
+++ b/lib/web_driver_client/w3c_wire_protocol_client/commands/clear_element.ex
@@ -35,9 +35,8 @@ defmodule WebDriverClient.W3CWireProtocolClient.Commands.ClearElement do
   @spec parse_response(HTTPResponse.t()) ::
           :ok | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response) do
-    with {:ok, w3c_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_response(w3c_response) do
-      :ok
+    with {:ok, w3c_response} <- ResponseParser.parse_response(http_response) do
+      ResponseParser.ensure_successful_response(w3c_response)
     end
   end
 end

--- a/lib/web_driver_client/w3c_wire_protocol_client/commands/click_element.ex
+++ b/lib/web_driver_client/w3c_wire_protocol_client/commands/click_element.ex
@@ -35,9 +35,8 @@ defmodule WebDriverClient.W3CWireProtocolClient.Commands.ClickElement do
   @spec parse_response(HTTPResponse.t()) ::
           :ok | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response) do
-    with {:ok, w3c_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_response(w3c_response) do
-      :ok
+    with {:ok, w3c_response} <- ResponseParser.parse_response(http_response) do
+      ResponseParser.ensure_successful_response(w3c_response)
     end
   end
 end

--- a/lib/web_driver_client/w3c_wire_protocol_client/commands/delete_cookies.ex
+++ b/lib/web_driver_client/w3c_wire_protocol_client/commands/delete_cookies.ex
@@ -28,9 +28,8 @@ defmodule WebDriverClient.W3CWireProtocolClient.Commands.DeleteCookies do
   @spec parse_response(HTTPResponse.t()) ::
           :ok | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response) do
-    with {:ok, w3c_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_response(w3c_response) do
-      :ok
+    with {:ok, w3c_response} <- ResponseParser.parse_response(http_response) do
+      ResponseParser.ensure_successful_response(w3c_response)
     end
   end
 end

--- a/lib/web_driver_client/w3c_wire_protocol_client/commands/dismiss_alert.ex
+++ b/lib/web_driver_client/w3c_wire_protocol_client/commands/dismiss_alert.ex
@@ -30,9 +30,8 @@ defmodule WebDriverClient.W3CWireProtocolClient.Commands.DismissAlert do
   @spec parse_response(HTTPResponse.t()) ::
           :ok | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response) do
-    with {:ok, w3c_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_response(w3c_response) do
-      :ok
+    with {:ok, w3c_response} <- ResponseParser.parse_response(http_response) do
+      ResponseParser.ensure_successful_response(w3c_response)
     end
   end
 end

--- a/lib/web_driver_client/w3c_wire_protocol_client/commands/end_session.ex
+++ b/lib/web_driver_client/w3c_wire_protocol_client/commands/end_session.ex
@@ -27,9 +27,8 @@ defmodule WebDriverClient.W3CWireProtocolClient.Commands.EndSession do
   @spec parse_response(HTTPResponse.t()) ::
           :ok | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response) do
-    with {:ok, w3c_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_response(w3c_response) do
-      :ok
+    with {:ok, w3c_response} <- ResponseParser.parse_response(http_response) do
+      ResponseParser.ensure_successful_response(w3c_response)
     end
   end
 end

--- a/lib/web_driver_client/w3c_wire_protocol_client/commands/fetch_active_element.ex
+++ b/lib/web_driver_client/w3c_wire_protocol_client/commands/fetch_active_element.ex
@@ -29,9 +29,8 @@ defmodule WebDriverClient.W3CWireProtocolClient.Commands.FetchActiveElement do
           {:ok, Element.t()} | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response) do
     with {:ok, w3c_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_response(w3c_response),
-         {:ok, element} <- ResponseParser.parse_element(w3c_response) do
-      {:ok, element}
+         :ok <- ResponseParser.ensure_successful_response(w3c_response) do
+      ResponseParser.parse_element(w3c_response)
     end
   end
 end

--- a/lib/web_driver_client/w3c_wire_protocol_client/commands/fetch_alert_text.ex
+++ b/lib/web_driver_client/w3c_wire_protocol_client/commands/fetch_alert_text.ex
@@ -28,9 +28,8 @@ defmodule WebDriverClient.W3CWireProtocolClient.Commands.FetchAlertText do
           {:ok, String.t()} | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response) do
     with {:ok, w3c_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_response(w3c_response),
-         {:ok, value} <- ResponseParser.parse_value(w3c_response) do
-      {:ok, value}
+         :ok <- ResponseParser.ensure_successful_response(w3c_response) do
+      ResponseParser.parse_value(w3c_response)
     end
   end
 end

--- a/lib/web_driver_client/w3c_wire_protocol_client/commands/fetch_cookies.ex
+++ b/lib/web_driver_client/w3c_wire_protocol_client/commands/fetch_cookies.ex
@@ -29,9 +29,8 @@ defmodule WebDriverClient.W3CWireProtocolClient.Commands.FetchCookies do
           {:ok, [Cookie.t()]} | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response) do
     with {:ok, w3c_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_response(w3c_response),
-         {:ok, cookies} <- ResponseParser.parse_cookies(w3c_response) do
-      {:ok, cookies}
+         :ok <- ResponseParser.ensure_successful_response(w3c_response) do
+      ResponseParser.parse_cookies(w3c_response)
     end
   end
 end

--- a/lib/web_driver_client/w3c_wire_protocol_client/commands/fetch_current_url.ex
+++ b/lib/web_driver_client/w3c_wire_protocol_client/commands/fetch_current_url.ex
@@ -31,9 +31,8 @@ defmodule WebDriverClient.W3CWireProtocolClient.Commands.FetchCurrentURL do
           {:ok, url} | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response) do
     with {:ok, w3c_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_response(w3c_response),
-         {:ok, url} <- ResponseParser.parse_url(w3c_response) do
-      {:ok, url}
+         :ok <- ResponseParser.ensure_successful_response(w3c_response) do
+      ResponseParser.parse_url(w3c_response)
     end
   end
 end

--- a/lib/web_driver_client/w3c_wire_protocol_client/commands/fetch_element_attribute.ex
+++ b/lib/web_driver_client/w3c_wire_protocol_client/commands/fetch_element_attribute.ex
@@ -38,9 +38,8 @@ defmodule WebDriverClient.W3CWireProtocolClient.Commands.FetchElementAttribute d
           {:ok, String.t()} | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response) do
     with {:ok, w3c_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_response(w3c_response),
-         {:ok, value} <- ResponseParser.parse_value(w3c_response) do
-      {:ok, value}
+         :ok <- ResponseParser.ensure_successful_response(w3c_response) do
+      ResponseParser.parse_value(w3c_response)
     end
   end
 end

--- a/lib/web_driver_client/w3c_wire_protocol_client/commands/fetch_element_displayed.ex
+++ b/lib/web_driver_client/w3c_wire_protocol_client/commands/fetch_element_displayed.ex
@@ -34,9 +34,8 @@ defmodule WebDriverClient.W3CWireProtocolClient.Commands.FetchElementDisplayed d
           {:ok, boolean} | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response) do
     with {:ok, w3c_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_response(w3c_response),
-         {:ok, boolean} <- ResponseParser.parse_boolean(w3c_response) do
-      {:ok, boolean}
+         :ok <- ResponseParser.ensure_successful_response(w3c_response) do
+      ResponseParser.parse_boolean(w3c_response)
     end
   end
 end

--- a/lib/web_driver_client/w3c_wire_protocol_client/commands/fetch_element_property.ex
+++ b/lib/web_driver_client/w3c_wire_protocol_client/commands/fetch_element_property.ex
@@ -38,9 +38,8 @@ defmodule WebDriverClient.W3CWireProtocolClient.Commands.FetchElementProperty do
           {:ok, String.t()} | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response) do
     with {:ok, w3c_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_response(w3c_response),
-         {:ok, value} <- ResponseParser.parse_value(w3c_response) do
-      {:ok, value}
+         :ok <- ResponseParser.ensure_successful_response(w3c_response) do
+      ResponseParser.parse_value(w3c_response)
     end
   end
 end

--- a/lib/web_driver_client/w3c_wire_protocol_client/commands/fetch_element_text.ex
+++ b/lib/web_driver_client/w3c_wire_protocol_client/commands/fetch_element_text.ex
@@ -34,9 +34,8 @@ defmodule WebDriverClient.W3CWireProtocolClient.Commands.FetchElementText do
           {:ok, String.t()} | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response) do
     with {:ok, w3c_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_response(w3c_response),
-         {:ok, value} <- ResponseParser.parse_value(w3c_response) do
-      {:ok, value}
+         :ok <- ResponseParser.ensure_successful_response(w3c_response) do
+      ResponseParser.parse_value(w3c_response)
     end
   end
 end

--- a/lib/web_driver_client/w3c_wire_protocol_client/commands/fetch_log_types.ex
+++ b/lib/web_driver_client/w3c_wire_protocol_client/commands/fetch_log_types.ex
@@ -31,9 +31,8 @@ defmodule WebDriverClient.W3CWireProtocolClient.Commands.FetchLogTypes do
           {:ok, [log_type]} | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response) do
     with {:ok, w3c_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_response(w3c_response),
-         {:ok, log_types} <- ResponseParser.parse_value(w3c_response) do
-      {:ok, log_types}
+         :ok <- ResponseParser.ensure_successful_response(w3c_response) do
+      ResponseParser.parse_value(w3c_response)
     end
   end
 end

--- a/lib/web_driver_client/w3c_wire_protocol_client/commands/fetch_logs.ex
+++ b/lib/web_driver_client/w3c_wire_protocol_client/commands/fetch_logs.ex
@@ -34,9 +34,8 @@ defmodule WebDriverClient.W3CWireProtocolClient.Commands.FetchLogs do
           {:ok, [LogEntry.t()]} | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response) do
     with {:ok, w3c_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_response(w3c_response),
-         {:ok, log_entries} <- ResponseParser.parse_log_entries(w3c_response) do
-      {:ok, log_entries}
+         :ok <- ResponseParser.ensure_successful_response(w3c_response) do
+      ResponseParser.parse_log_entries(w3c_response)
     end
   end
 end

--- a/lib/web_driver_client/w3c_wire_protocol_client/commands/fetch_page_source.ex
+++ b/lib/web_driver_client/w3c_wire_protocol_client/commands/fetch_page_source.ex
@@ -30,9 +30,8 @@ defmodule WebDriverClient.W3CWireProtocolClient.Commands.FetchPageSource do
           {:ok, page_source} | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response) do
     with {:ok, w3c_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_response(w3c_response),
-         {:ok, page_source} <- ResponseParser.parse_value(w3c_response) do
-      {:ok, page_source}
+         :ok <- ResponseParser.ensure_successful_response(w3c_response) do
+      ResponseParser.parse_value(w3c_response)
     end
   end
 end

--- a/lib/web_driver_client/w3c_wire_protocol_client/commands/fetch_server_status.ex
+++ b/lib/web_driver_client/w3c_wire_protocol_client/commands/fetch_server_status.ex
@@ -28,9 +28,8 @@ defmodule WebDriverClient.W3CWireProtocolClient.Commands.FetchServerStatus do
           {:ok, ServerStatus.t()} | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response) do
     with {:ok, w3c_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_response(w3c_response),
-         {:ok, server_status} <- ResponseParser.parse_server_status(w3c_response) do
-      {:ok, server_status}
+         :ok <- ResponseParser.ensure_successful_response(w3c_response) do
+      ResponseParser.parse_server_status(w3c_response)
     end
   end
 end

--- a/lib/web_driver_client/w3c_wire_protocol_client/commands/fetch_sessions.ex
+++ b/lib/web_driver_client/w3c_wire_protocol_client/commands/fetch_sessions.ex
@@ -28,9 +28,8 @@ defmodule WebDriverClient.W3CWireProtocolClient.Commands.FetchSessions do
           {:ok, [Session.t()]} | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response, %Config{} = config) do
     with {:ok, w3c_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_response(w3c_response),
-         {:ok, session} <- ResponseParser.parse_fetch_sessions_response(w3c_response, config) do
-      {:ok, session}
+         :ok <- ResponseParser.ensure_successful_response(w3c_response) do
+      ResponseParser.parse_fetch_sessions_response(w3c_response, config)
     end
   end
 end

--- a/lib/web_driver_client/w3c_wire_protocol_client/commands/fetch_title.ex
+++ b/lib/web_driver_client/w3c_wire_protocol_client/commands/fetch_title.ex
@@ -30,9 +30,8 @@ defmodule WebDriverClient.W3CWireProtocolClient.Commands.FetchTitle do
           {:ok, title} | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response) do
     with {:ok, w3c_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_response(w3c_response),
-         {:ok, title} <- ResponseParser.parse_value(w3c_response) do
-      {:ok, title}
+         :ok <- ResponseParser.ensure_successful_response(w3c_response) do
+      ResponseParser.parse_value(w3c_response)
     end
   end
 end

--- a/lib/web_driver_client/w3c_wire_protocol_client/commands/fetch_window_rect.ex
+++ b/lib/web_driver_client/w3c_wire_protocol_client/commands/fetch_window_rect.ex
@@ -29,9 +29,8 @@ defmodule WebDriverClient.W3CWireProtocolClient.Commands.FetchWindowRect do
           {:ok, Rect.t()} | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response) do
     with {:ok, w3c_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_response(w3c_response),
-         {:ok, url} <- ResponseParser.parse_rect(w3c_response) do
-      {:ok, url}
+         :ok <- ResponseParser.ensure_successful_response(w3c_response) do
+      ResponseParser.parse_rect(w3c_response)
     end
   end
 end

--- a/lib/web_driver_client/w3c_wire_protocol_client/commands/find_element.ex
+++ b/lib/web_driver_client/w3c_wire_protocol_client/commands/find_element.ex
@@ -48,9 +48,8 @@ defmodule WebDriverClient.W3CWireProtocolClient.Commands.FindElement do
           {:ok, Element.t()} | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response) do
     with {:ok, w3c_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_response(w3c_response),
-         {:ok, element} <- ResponseParser.parse_element(w3c_response) do
-      {:ok, element}
+         :ok <- ResponseParser.ensure_successful_response(w3c_response) do
+      ResponseParser.parse_element(w3c_response)
     end
   end
 

--- a/lib/web_driver_client/w3c_wire_protocol_client/commands/find_elements.ex
+++ b/lib/web_driver_client/w3c_wire_protocol_client/commands/find_elements.ex
@@ -48,9 +48,8 @@ defmodule WebDriverClient.W3CWireProtocolClient.Commands.FindElements do
           {:ok, [Element.t()]} | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response) do
     with {:ok, w3c_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_response(w3c_response),
-         {:ok, elements} <- ResponseParser.parse_elements(w3c_response) do
-      {:ok, elements}
+         :ok <- ResponseParser.ensure_successful_response(w3c_response) do
+      ResponseParser.parse_elements(w3c_response)
     end
   end
 

--- a/lib/web_driver_client/w3c_wire_protocol_client/commands/find_elements_from_element.ex
+++ b/lib/web_driver_client/w3c_wire_protocol_client/commands/find_elements_from_element.ex
@@ -49,9 +49,8 @@ defmodule WebDriverClient.W3CWireProtocolClient.Commands.FindElementsFromElement
           {:ok, [Element.t()]} | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response) do
     with {:ok, w3c_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_response(w3c_response),
-         {:ok, elements} <- ResponseParser.parse_elements(w3c_response) do
-      {:ok, elements}
+         :ok <- ResponseParser.ensure_successful_response(w3c_response) do
+      ResponseParser.parse_elements(w3c_response)
     end
   end
 

--- a/lib/web_driver_client/w3c_wire_protocol_client/commands/navigate_to.ex
+++ b/lib/web_driver_client/w3c_wire_protocol_client/commands/navigate_to.ex
@@ -31,9 +31,8 @@ defmodule WebDriverClient.W3CWireProtocolClient.Commands.NavigateTo do
   @spec parse_response(HTTPResponse.t()) ::
           :ok | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response) do
-    with {:ok, w3c_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_response(w3c_response) do
-      :ok
+    with {:ok, w3c_response} <- ResponseParser.parse_response(http_response) do
+      ResponseParser.ensure_successful_response(w3c_response)
     end
   end
 end

--- a/lib/web_driver_client/w3c_wire_protocol_client/commands/send_alert_text.ex
+++ b/lib/web_driver_client/w3c_wire_protocol_client/commands/send_alert_text.ex
@@ -30,9 +30,8 @@ defmodule WebDriverClient.W3CWireProtocolClient.Commands.SendAlertText do
   @spec parse_response(HTTPResponse.t()) ::
           :ok | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response) do
-    with {:ok, w3c_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_response(w3c_response) do
-      :ok
+    with {:ok, w3c_response} <- ResponseParser.parse_response(http_response) do
+      ResponseParser.ensure_successful_response(w3c_response)
     end
   end
 end

--- a/lib/web_driver_client/w3c_wire_protocol_client/commands/send_keys_to_element.ex
+++ b/lib/web_driver_client/w3c_wire_protocol_client/commands/send_keys_to_element.ex
@@ -38,9 +38,8 @@ defmodule WebDriverClient.W3CWireProtocolClient.Commands.SendKeysToElement do
   @spec parse_response(HTTPResponse.t()) ::
           :ok | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response) do
-    with {:ok, w3c_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_response(w3c_response) do
-      :ok
+    with {:ok, w3c_response} <- ResponseParser.parse_response(http_response) do
+      ResponseParser.ensure_successful_response(w3c_response)
     end
   end
 

--- a/lib/web_driver_client/w3c_wire_protocol_client/commands/set_cookie.ex
+++ b/lib/web_driver_client/w3c_wire_protocol_client/commands/set_cookie.ex
@@ -42,9 +42,8 @@ defmodule WebDriverClient.W3CWireProtocolClient.Commands.SetCookie do
   @spec parse_response(HTTPResponse.t()) ::
           :ok | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response) do
-    with {:ok, w3c_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_response(w3c_response) do
-      :ok
+    with {:ok, w3c_response} <- ResponseParser.parse_response(http_response) do
+      ResponseParser.ensure_successful_response(w3c_response)
     end
   end
 end

--- a/lib/web_driver_client/w3c_wire_protocol_client/commands/set_window_rect.ex
+++ b/lib/web_driver_client/w3c_wire_protocol_client/commands/set_window_rect.ex
@@ -32,9 +32,8 @@ defmodule WebDriverClient.W3CWireProtocolClient.Commands.SetWindowRect do
   @spec parse_response(HTTPResponse.t()) ::
           :ok | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response) do
-    with {:ok, w3c_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_response(w3c_response) do
-      :ok
+    with {:ok, w3c_response} <- ResponseParser.parse_response(http_response) do
+      ResponseParser.ensure_successful_response(w3c_response)
     end
   end
 end

--- a/lib/web_driver_client/w3c_wire_protocol_client/commands/start_session.ex
+++ b/lib/web_driver_client/w3c_wire_protocol_client/commands/start_session.ex
@@ -33,9 +33,8 @@ defmodule WebDriverClient.W3CWireProtocolClient.Commands.StartSession do
           {:ok, Session.t()} | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response, %Config{} = config) do
     with {:ok, w3c_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_response(w3c_response),
-         {:ok, session} <- ResponseParser.parse_start_session_response(w3c_response, config) do
-      {:ok, session}
+         :ok <- ResponseParser.ensure_successful_response(w3c_response) do
+      ResponseParser.parse_start_session_response(w3c_response, config)
     end
   end
 end

--- a/lib/web_driver_client/w3c_wire_protocol_client/commands/take_screenshot.ex
+++ b/lib/web_driver_client/w3c_wire_protocol_client/commands/take_screenshot.ex
@@ -28,9 +28,8 @@ defmodule WebDriverClient.W3CWireProtocolClient.Commands.TakeScreenshot do
           {:ok, binary} | {:error, UnexpectedResponseError.t() | WebDriverError.t()}
   def parse_response(%HTTPResponse{} = http_response) do
     with {:ok, w3c_response} <- ResponseParser.parse_response(http_response),
-         :ok <- ResponseParser.ensure_successful_response(w3c_response),
-         {:ok, image_data} <- ResponseParser.parse_image_data(w3c_response) do
-      {:ok, image_data}
+         :ok <- ResponseParser.ensure_successful_response(w3c_response) do
+      ResponseParser.parse_image_data(w3c_response)
     end
   end
 end


### PR DESCRIPTION
Follow up to #116 

This PR resolves `Refactor.RedundantWithClauseResult` at 123 sites.

We could also run credo _only_ on the modern lockfile, I'm on the fence.

Full disclosure: I had claude make these mechanical changes on my behalf.

BEGIN_COMMIT_OVERRIDE
refactor: fix credo violations
END_COMMIT_OVERRIDE