### PR TITLE
disable dependabot for elixir, enable it for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,29 +1,8 @@
 version: 2
 updates:
-- package-ecosystem: mix
+- package-ecosystem: github-actions
   directory: "/"
   schedule:
-    interval: daily
-    time: "12:00"
-  open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: ex_doc
-    versions:
-    - 0.23.0
-    - 0.24.0
-    - 0.24.1
-  - dependency-name: hackney
-    versions:
-    - 1.17.0
-    - 1.17.1
-    - 1.17.2
-    - 1.17.3
-  - dependency-name: credo
-    versions:
-    - 1.5.4
-  - dependency-name: excoveralls
-    versions:
-    - 0.13.4
-  - dependency-name: tesla
-    versions:
-    - 1.4.0
+    interval: monthly
+  cooldown:
+    default-days: 7


### PR DESCRIPTION
* not much point in keeping the `mix.lock` up to date aggressively since consumers use the version ranges from `mix.lock`
* now that we are pinning GHA helpers in #120 its probably more important to keep those up to date