### PR TITLE
Release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.3 - 2026-06-14
+
+* Adds Hackney 4 compatibility.
+* Increases minimum elixir version to 1.17.
+
 ## 0.2 - 2021-09-13
 
 * Increases minimum elixir version to 1.8.

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ by adding `web_driver_client` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:web_driver_client, "~> 0.2.0"}
+    {:web_driver_client, "~> 0.3.0"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule WebDriverClient.MixProject do
   use Mix.Project
 
-  @version "0.2.0"
+  @version "0.3.0"
 
   def project do
     [


### PR DESCRIPTION
Now that [httpoison 3.0.0](https://github.com/edgurgel/httpoison/releases/tag/v3.0.0) is released, all we need to do to let wallaby consumers use hackney 4.x is bump web_driver_client and then in turn wallaby.